### PR TITLE
Bump loader-utils version to 1.4.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,6 @@
   "homepage": "https://github.com/nkt/yml-loader#readme",
   "dependencies": {
     "js-yaml": "^3.8.3",
-    "loader-utils": "^1.1.0"
+    "loader-utils": "^1.4.x"
   }
 }


### PR DESCRIPTION
There is a detected critical security vulnerability on `loader-utils` package detailed here:
https://nvd.nist.gov/vuln/detail/CVE-2022-37603

This PR updates the version to a safe one in order to prevent any malicious attack.

Please consider to release a new minor version, ton of people still using this package.